### PR TITLE
Automate inserting  values to cluster egress and ingress configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -314,6 +314,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f67490120d0901f6675471d2a73b0e54ecb3b3255ba320f6d05efb9342b5e404"
+  name = "github.com/openshift/api"
+  packages = ["config/v1"]
+  pruneopts = "NT"
+  revision = "4706c46ddae58211c6602e6e7f3486df3f21687a"
+
+[[projects]]
+  branch = "master"
   digest = "1:afbc22826491c47d59cc85d27be704fb82a479064d774d3ce58a131bf2426141"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
@@ -915,16 +923,20 @@
   input-imports = [
     "github.com/go-openapi/spec",
     "github.com/jcrossley3/manifestival/yaml",
+    "github.com/openshift/api/config/v1",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/log/zap",
     "github.com/operator-framework/operator-sdk/pkg/metrics",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/spf13/pflag",
+    "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",

--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -121,17 +121,22 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	// set any additional values after yaml has been applied
-	if err := r.postInstall(); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	if err := r.deleteObsoleteResources(); err != nil {
 		return reconcile.Result{}, err
 	}
+
 	if err := r.checkForMinikube(); err != nil {
 		return reconcile.Result{}, err
 	}
+
+	if err := r.updateServiceNetwork(); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateDomain(); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -206,20 +211,6 @@ func (r *ReconcileInstall) checkForMinikube() error {
 
 }
 
-// Set additional properties after applying yaml.
-func (r *ReconcileInstall) postInstall() error {
-
-	if err := r.updateDomainConfigMap(); err != nil {
-		return err
-	}
-
-	if err := r.updateNetworkConfigMap(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Get Service Network from cluster resource
 func (r *ReconcileInstall) getServiceNetwork() string {
 	networkConfig := &configv1.Network{}
@@ -247,7 +238,7 @@ func (r *ReconcileInstall) getDomain() string {
 }
 
 // Set domain in the Config Map
-func (r *ReconcileInstall) updateDomainConfigMap() error {
+func (r *ReconcileInstall) updateDomain() error {
 
 	// retrieve domain for configuring for ingress traffic
 	domain := r.getDomain()
@@ -269,7 +260,7 @@ func (r *ReconcileInstall) updateDomainConfigMap() error {
 }
 
 // Set istio.sidecar.includeOutboundIPRanges property with service network
-func (r *ReconcileInstall) updateNetworkConfigMap() error {
+func (r *ReconcileInstall) updateServiceNetwork() error {
 
 	// retrieve service networks for configuring egress traffic
 	serviceNetwork := r.getServiceNetwork()

--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/jcrossley3/manifestival/yaml"
 
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -38,9 +39,6 @@ const (
 
 	// ConfigMap name for config-domain
 	domainConfigMapName = "config-domain"
-
-	// Key name for example config in config map
-	exampleKey = "_example"
 
 	// cluster object name to retrieve network/domain info
 	clusterObjectName = "cluster"
@@ -142,26 +140,6 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
-	// retrieve service networks for configuring egress traffic
-	networkConfig := &configv1.Network{}
-	serviceNetwork := ""
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: clusterObjectName}, networkConfig); err != nil {
-		reqLogger.Info("Network Config is not available.")
-	} else if len(networkConfig.Spec.ServiceNetwork) > 0 {
-		serviceNetwork = strings.Join(networkConfig.Spec.ServiceNetwork, ",")
-		reqLogger.Info("Network Config is available", "Service Network", serviceNetwork)
-	}
-
-	// retrieve domain for configuring for ingress traffic
-	ingressConfig := &configv1.Ingress{}
-	domain := ""
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: clusterObjectName}, ingressConfig); err != nil {
-		reqLogger.Info("Ingress Config is not available.")
-	} else {
-		domain = ingressConfig.Spec.Domain
-		reqLogger.Info("Ingress Config is available", "Domain", domain)
-	}
-
 	// Apply the resources in the YAML file
 	err = r.config.Apply(instance)
 	if err != nil {
@@ -176,37 +154,78 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	updateDomain(r.client, reqLogger)
+	updateServiceNetwork(r.client, reqLogger)
+
+	return reconcile.Result{}, nil
+}
+
+func getServiceNetwork(client client.Client, logger logr.Logger) string {
+
+	networkConfig := &configv1.Network{}
+
+	serviceNetwork := ""
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: clusterObjectName}, networkConfig); err != nil {
+		logger.Info("Network Config is not available.")
+	} else if len(networkConfig.Spec.ServiceNetwork) > 0 {
+		serviceNetwork = strings.Join(networkConfig.Spec.ServiceNetwork, ",")
+		logger.Info("Network Config is available", "Service Network", serviceNetwork)
+	}
+
+	return serviceNetwork
+}
+
+func getDomain(client client.Client, logger logr.Logger) string {
+	ingressConfig := &configv1.Ingress{}
+	domain := ""
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: clusterObjectName}, ingressConfig); err != nil {
+		logger.Info("Ingress Config is not available.")
+	} else {
+		domain = ingressConfig.Spec.Domain
+		logger.Info("Ingress Config is available", "Domain", domain)
+	}
+
+	return domain
+}
+
+func updateDomain(client client.Client, logger logr.Logger) {
+
+	// retrieve domain for configuring for ingress traffic
+	domain := getDomain(client, logger)
+
 	// If domain is available, update config-domain config map
 	if len(domain) > 0 {
 		configMap := &corev1.ConfigMap{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: knativeServingNamespace,
+		if err := client.Get(context.TODO(), types.NamespacedName{Namespace: knativeServingNamespace,
 			Name: domainConfigMapName}, configMap); err != nil {
-			reqLogger.Error(err, "Failed to get configmap for config-domain")
+			logger.Error(err, "Failed to get configmap for config-domain")
 		} else {
-			delete(configMap.Data, exampleKey)
 			configMap.Data[domain] = ""
-			if err := r.client.Update(context.TODO(), configMap); err != nil {
-				reqLogger.Error(err, "Failed to update configmap for config-domain")
+			if err := client.Update(context.TODO(), configMap); err != nil {
+				logger.Error(err, "Failed to update configmap for config-domain")
 			}
 		}
 	}
+}
+
+func updateServiceNetwork(client client.Client, logger logr.Logger) {
+
+	// retrieve service networks for configuring egress traffic
+	serviceNetwork := getServiceNetwork(client, logger)
 
 	// If service network is available, update config-network config map
 	if len(serviceNetwork) > 0 {
 		configMap := &corev1.ConfigMap{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: knativeServingNamespace,
+		if err := client.Get(context.TODO(), types.NamespacedName{Namespace: knativeServingNamespace,
 			Name: networkConfigMapName}, configMap); err != nil {
-			reqLogger.Error(err, "Failed to get configmap for config-network")
+			logger.Error(err, "Failed to get configmap for config-network")
 		} else {
-			delete(configMap.Data, exampleKey)
 			configMap.Data[istioSideCarIncludeOutboundIPRangesProp] = serviceNetwork
-			if err := r.client.Update(context.TODO(), configMap); err != nil {
-				reqLogger.Error(err, "Failed to update configmap for config-network")
+			if err := client.Update(context.TODO(), configMap); err != nil {
+				logger.Error(err, "Failed to update configmap for config-network")
 			}
 		}
 	}
-
-	return reconcile.Result{}, nil
 }
 
 func getResourceVersion() string {


### PR DESCRIPTION
The purpose of this PR is to add the ability to automatically fill Istio includeOutboundIPRanges (SRVKS-33) and cluster domain base name (SRVKS-34) so that egress and ingress enpoints are correctly configured, respectively.

This PR fixes:
https://jira.coreos.com/browse/SRVKS-33
https://jira.coreos.com/browse/SRVKS-34

