### PR TITLE
Automatically install the Maistra Operator and ControlPlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ appropriately for your cluster in the `default` namespace:
 
 ### Istio
 
-Version 0.5.x of Knative Serving requires Istio CRD's:
+On OpenShift, Istio will get installed automatically if not already
+present by using the [Maistra Operator](https://maistra.io/).
+
+For other platforms, version 0.5.x of Knative Serving requires Istio CRD's:
 
     kubectl apply -f https://github.com/knative/serving/releases/download/v0.5.2/istio-crds.yaml
 

--- a/deploy/resources/maistra/maistra-controlplane-0.10.0.yaml
+++ b/deploy/resources/maistra/maistra-controlplane-0.10.0.yaml
@@ -1,0 +1,43 @@
+apiVersion: istio.openshift.com/v1alpha3
+kind: ControlPlane
+metadata:
+  name: minimal-istio
+spec:
+  istio:
+    global:
+      # use community images
+      hub: "maistra"
+      tag: 0.10.0
+      proxy:
+        autoInject: disabled
+      useMCP: false
+      disablePolicyChecks: false
+      omitSidecarInjectorConfigMap: true
+    galley:
+      enabled: false
+    gateways:
+      istio-ingressgateway:
+        autoscaleEnabled: false
+      istio-egressgateway:
+        enabled: false
+    grafana:
+      enabled: false
+    mixer:
+      enabled: false
+      policy:
+        enabled: false
+      telemetry:
+        enabled: false
+    pilot:
+      autoscaleEnabled: false
+      sidecar: false
+    prometheus:
+      enabled: false
+    security:
+      enabled: false
+    sidecarInjectorWebhook:
+      enabled: false
+    kiali:
+      enabled: false
+    tracing:
+      enabled: false

--- a/deploy/resources/maistra/maistra-operator-0.10.yaml
+++ b/deploy/resources/maistra/maistra-operator-0.10.yaml
@@ -1,0 +1,472 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installations.istio.openshift.com
+spec:
+  group: istio.openshift.com
+  names:
+    kind: Installation
+    plural: installations
+    singular: installation
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: controlplanes.istio.openshift.com
+spec:
+  group: istio.openshift.com
+  names:
+    kind: ControlPlane
+    listKind: ControlPlaneList
+    plural: controlplanes
+    singular: controlplane
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - namespaces
+  - routes
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - clusterissuers
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - authentication.istio.io
+  resources:
+  # for galley, *: get, list, watch
+  # for mixer, *: create, get, list, watch
+  # for pilot, *: *
+  # for istio-authenticated, *: *
+  - '*'
+  - meshpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - config.istio.io
+  resources:
+  # for galley, *: get, list, watch
+  # for pilot, *: *
+  # for istio-authenticated, *: *
+  - '*'
+  - attributemanifests
+  - handlers
+  - logentries
+  - rules
+  - metrics
+  - kuberneteses
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  # for galley, *: get, list, watch
+  # for pilot, *: *
+  # for istio-authenticated, *: *
+  - '*'
+  - gateways
+  - destinationrules
+  - virtualservices
+  - envoyfilters
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - istio.openshift.com
+  resources:
+  - '*'
+  - istiocontrolplanes
+  - installations
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - '*'
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - '*'
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  - projectrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - '*'
+# for galley (pilot and prometheus also watch nodes)
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - istio-galley
+  - istio-sidecar-injector
+  verbs:
+  - update
+# for mixer
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+# for pilot
+# for istio-authenticated, *: *
+- apiGroups:
+  - rbac.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - '*'
+# prometheus
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs: 
+  - "/metrics"
+  verbs:
+  - get
+# citadel
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+# kiali
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - '*'
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["config.istio.io"]
+  resources:
+  - apikeys
+  - authorizations
+  - checknothings
+  - circonuses
+  - deniers
+  - fluentds
+  - handlers
+  - kubernetesenvs
+  - kuberneteses
+  - listcheckers
+  - listentries
+  - logentries
+  - memquotas
+  - metrics
+  - opas
+  - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
+  - rbacs
+  - reportnothings
+  - rules
+  - solarwindses
+  - stackdrivers
+  - statsds
+  - stdios
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["networking.istio.io"]
+  resources:
+  - destinationrules
+  - gateways
+  - serviceentries
+  - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-operator
+  namespace: istio-operator
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-operator-account-istio-operator-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  namespace: istio-operator
+  name: istio-operator
+roleRef:
+  kind: ClusterRole
+  name: istio-operator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-operator
+  namespace: istio-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: istio-operator
+  template:
+    metadata:
+      labels:
+        name: istio-operator
+    spec:
+      serviceAccountName: istio-operator
+      volumes:
+      - name: discovery-cache
+        emptyDir:
+          medium: Memory
+      containers:
+        - name: istio-operator
+          image: maistra/istio-operator-centos7:0.10.0
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - istio-operator
+          - --discoveryCacheDir
+          - /home/istio-operator/.kube/cache/discovery
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "istio-operator"
+          volumeMounts:
+          - name: discovery-cache
+            mountPath: /home/istio-operator/.kube/cache/discovery

--- a/pkg/controller/install/add_minikube.go
+++ b/pkg/controller/install/add_minikube.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	platformFuncs = append(platformFuncs, minikube.Configure)
+	platformTransformFuncs = append(platformTransformFuncs, minikube.Configure)
 }

--- a/pkg/controller/install/add_openshift.go
+++ b/pkg/controller/install/add_openshift.go
@@ -5,5 +5,6 @@ import (
 )
 
 func init() {
-	platformFuncs = append(platformFuncs, openshift.Configure)
+	platformPrereqFuncs = append(platformPrereqFuncs, openshift.EnsureMaistra)
+	platformTransformFuncs = append(platformTransformFuncs, openshift.Configure)
 }


### PR DESCRIPTION
On OpenShift, we detect if the Maistra Operator CRD is already
installed. If not, and Istio CRDs are also not already present, then
we install the Maistra Operator and a minimal Maistra ControlPlane.

If we detect that the Maistra Operator is already installed but no
Maistra ControlPlane then we install the same minimal Maistra
ControlPlane.