### PR TITLE
Automatically install knative-openshift-ingress

### DIFF
--- a/deploy/resources/openshift-ingress/openshift-ingress-0.0.4.yaml
+++ b/deploy/resources/openshift-ingress/openshift-ingress-0.0.4.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-openshift-ingress
+  namespace: knative-serving
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-openshift-ingress
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  - configmaps
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - clusteringresses
+  - clusteringresses/status
+  - clusteringresses/finalizers
+  verbs:
+  - "*"
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  - routes/status
+  - routes/finalizers
+  verbs:
+  - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-openshift-ingress
+subjects:
+- kind: ServiceAccount
+  name: knative-openshift-ingress
+  namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-openshift-ingress
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knative-openshift-ingress
+  namespace: knative-serving
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: knative-openshift-ingress
+  template:
+    metadata:
+      labels:
+        name: knative-openshift-ingress
+    spec:
+      serviceAccountName: knative-openshift-ingress
+      containers:
+        - name: knative-openshift-ingress
+          image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.4
+          command:
+          - knative-openshift-ingress
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: "" # watch all namespaces for ClusterIngress
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "knative-openshift-ingress"

--- a/pkg/controller/install/add_openshift.go
+++ b/pkg/controller/install/add_openshift.go
@@ -5,6 +5,7 @@ import (
 )
 
 func init() {
-	platformPrereqFuncs = append(platformPrereqFuncs, openshift.EnsureMaistra)
+	platformPreInstallFuncs = append(platformPreInstallFuncs, openshift.EnsureMaistra)
+	platformPostInstallFuncs = append(platformPostInstallFuncs, openshift.EnsureOpenshiftIngress)
 	platformTransformFuncs = append(platformTransformFuncs, openshift.Configure)
 }


### PR DESCRIPTION
After installing Knative Serving the operator will now ensure the
knative-openshift-ingress operator is deployed so that OpenShift
Routes get created automatically for every Knative Route.