### PR TITLE
Cleaning up the platform-specific extensions a bit

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1268,6 +1268,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/go-logr/logr",
     "github.com/go-openapi/spec",
     "github.com/jcrossley3/manifestival",
     "github.com/knative/pkg/apis",
@@ -1282,8 +1283,8 @@
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/spf13/pflag",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
-    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/pkg/apis/serving/v1alpha1/install_types.go
+++ b/pkg/apis/serving/v1alpha1/install_types.go
@@ -34,6 +34,7 @@ type InstallStatus struct {
 	// https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// The version of the installed release
+	// +optional
 	Version string `json:"version,omitempty"`
 	// The latest available observations of a resource's current state.
 	// +optional

--- a/pkg/controller/install/add_minikube.go
+++ b/pkg/controller/install/add_minikube.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	platformTransformFuncs = append(platformTransformFuncs, minikube.Configure)
+	platforms = append(platforms, minikube.Configure)
 }

--- a/pkg/controller/install/add_openshift.go
+++ b/pkg/controller/install/add_openshift.go
@@ -5,7 +5,5 @@ import (
 )
 
 func init() {
-	platformPreInstallFuncs = append(platformPreInstallFuncs, openshift.EnsureMaistra)
-	platformPostInstallFuncs = append(platformPostInstallFuncs, openshift.EnsureOpenshiftIngress)
-	platformTransformFuncs = append(platformTransformFuncs, openshift.Configure)
+	platforms = append(platforms, openshift.Configure)
 }

--- a/pkg/controller/install/common/extensions.go
+++ b/pkg/controller/install/common/extensions.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	mf "github.com/jcrossley3/manifestival"
+	servingv1alpha1 "github.com/openshift-knative/knative-serving-operator/pkg/apis/serving/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("common")
+
+type Platforms []func(client.Client, *runtime.Scheme) (*Extension, error)
+type Extender func(*servingv1alpha1.Install) error
+type Extensions []Extension
+type Extension struct {
+	Transformers []mf.Transformer
+	PreInstalls  []Extender
+	PostInstalls []Extender
+}
+
+func (platforms Platforms) Extend(c client.Client, scheme *runtime.Scheme) (result Extensions, err error) {
+	for _, fn := range platforms {
+		ext, err := fn(c, scheme)
+		if err != nil {
+			return result, err
+		}
+		if ext != nil {
+			result = append(result, *ext)
+		}
+	}
+	return
+}
+
+func (exts Extensions) Transform(instance *servingv1alpha1.Install) []mf.Transformer {
+	result := []mf.Transformer{
+		mf.InjectOwner(instance),
+		mf.InjectNamespace(instance.GetNamespace()),
+	}
+	for _, extension := range exts {
+		result = append(result, extension.Transformers...)
+	}
+	// Let any config in instance override everything else
+	return append(result, func(u *unstructured.Unstructured) *unstructured.Unstructured {
+		if u.GetKind() == "ConfigMap" {
+			if data, ok := instance.Spec.Config[u.GetName()[7:]]; ok {
+				UpdateConfigMap(u, data, log)
+			}
+		}
+		return u
+	})
+}
+
+func (exts Extensions) PreInstall(instance *servingv1alpha1.Install) error {
+	for _, extension := range exts {
+		for _, f := range extension.PreInstalls {
+			if err := f(instance); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (exts Extensions) PostInstall(instance *servingv1alpha1.Install) error {
+	for _, extension := range exts {
+		for _, f := range extension.PostInstalls {
+			if err := f(instance); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/install/minikube/minikube.go
+++ b/pkg/controller/install/minikube/minikube.go
@@ -17,15 +17,15 @@ import (
 var log = logf.Log.WithName("minikube")
 
 // Configure minikube if we're soaking in it
-func Configure(c client.Client, _ *runtime.Scheme) []mf.Transformer {
+func Configure(c client.Client, _ *runtime.Scheme) (*common.Extension, error) {
 	node := &v1.Node{}
 	if err := c.Get(context.TODO(), types.NamespacedName{Name: "minikube"}, node); err != nil {
 		if !errors.IsNotFound(err) {
 			log.Error(err, "Unable to query for minikube node")
 		}
-		return nil // not running on minikube
+		return nil, nil // not running on minikube
 	}
-	return []mf.Transformer{egress}
+	return &common.Extension{Transformers: []mf.Transformer{egress}}, nil
 }
 
 func egress(u *unstructured.Unstructured) *unstructured.Unstructured {

--- a/pkg/controller/install/minikube/minikube.go
+++ b/pkg/controller/install/minikube/minikube.go
@@ -14,7 +14,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("minikube")
+var (
+	extension = common.Extension{
+		Transformers: []mf.Transformer{egress},
+	}
+	log = logf.Log.WithName("minikube")
+)
 
 // Configure minikube if we're soaking in it
 func Configure(c client.Client, _ *runtime.Scheme) (*common.Extension, error) {
@@ -23,9 +28,10 @@ func Configure(c client.Client, _ *runtime.Scheme) (*common.Extension, error) {
 		if !errors.IsNotFound(err) {
 			log.Error(err, "Unable to query for minikube node")
 		}
-		return nil, nil // not running on minikube
+		// Not running in minikube
+		return nil, nil
 	}
-	return &common.Extension{Transformers: []mf.Transformer{egress}}, nil
+	return &extension, nil
 }
 
 func egress(u *unstructured.Unstructured) *unstructured.Unstructured {


### PR DESCRIPTION
An attempt at preventing every function from having to detect whether it's on the correct platform or not. Instead, we just need to do it once in each platform's package.