### PR TITLE
Transform the controller rather than update post-install

### DIFF
--- a/pkg/controller/install/openshift/openshift.go
+++ b/pkg/controller/install/openshift/openshift.go
@@ -24,16 +24,18 @@ import (
 const (
 	maistraOperatorNamespace     = "istio-operator"
 	maistraControlPlaneNamespace = "istio-system"
+	caBundleConfigMapName        = "config-service-ca"
 )
 
 var (
 	extension = common.Extension{
-		Transformers: []mf.Transformer{ingress, egress, ensureOpenShiftRegistryForConfigMap},
-		PreInstalls:  []common.Extender{ensureMaistra, ensureConfigMapForCrt},
-		PostInstalls: []common.Extender{ensureOpenshiftIngress, updateDeploymentController},
+		Transformers: []mf.Transformer{ingress, egress, openShiftRegistry, deploymentController},
+		PreInstalls:  []common.Extender{ensureMaistra, caBundleConfigMap},
+		PostInstalls: []common.Extender{ensureOpenshiftIngress},
 	}
-	log = logf.Log.WithName("openshift")
-	api client.Client
+	log    = logf.Log.WithName("openshift")
+	api    client.Client
+	scheme *runtime.Scheme
 )
 
 // Configure OpenShift if we're soaking in it
@@ -52,6 +54,7 @@ func Configure(c client.Client, s *runtime.Scheme) (*common.Extension, error) {
 	}
 
 	api = c
+	scheme = s
 	return &extension, nil
 }
 
@@ -110,66 +113,6 @@ func ensureOpenshiftIngress(instance *servingv1alpha1.Install) error {
 		log.Error(err, "Unable to create Knative OpenShift Ingress operator install manifest")
 		return err
 	}
-	return nil
-}
-
-func updateDeploymentController(instance *servingv1alpha1.Install) error {
-	depName := "controller"
-	cmName := "config-service-ca"
-	volName := "service-ca"
-
-	// Check the existance of configmap before updating the deployment/controller
-	cm := &v1.ConfigMap{}
-	if err := api.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: instance.GetNamespace()}, cm); err != nil {
-		return err
-	}
-
-	if _, ok := cm.Data["service-ca.crt"]; ok {
-		found := &appsv1.Deployment{}
-		if err := api.Get(context.TODO(), types.NamespacedName{Name: depName, Namespace: instance.GetNamespace()}, found); err != nil {
-			return err
-		}
-
-		/* Deployment exist so update the deployment controller with volume, volumeMount and env.
-		oc -n $ns set volume deployment/controller --add --name=service-ca --configmap-name=$configmap_name --mount-path=$mount_path
-		oc -n $ns set env deployment/controller SSL_CERT_FILE=$mount_path/$cert_name */
-
-		v := v1.Volume{
-			Name: volName,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: cmName,
-					},
-				},
-			},
-		}
-
-		found.Spec.Template.Spec.Volumes = append(found.Spec.Template.Spec.Volumes, v)
-
-		vMount := v1.VolumeMount{
-			Name:      "service-ca",
-			MountPath: "/var/run/secrets/kubernetes.io/servicecerts",
-		}
-
-		for j := range found.Spec.Template.Spec.Containers {
-			found.Spec.Template.Spec.Containers[j].VolumeMounts = append(found.Spec.Template.Spec.Containers[j].VolumeMounts, vMount)
-		}
-
-		envVar := &v1.EnvVar{
-			Name:  "SSL_CERT_FILE",
-			Value: "/var/run/secrets/kubernetes.io/servicecerts/service-ca.crt",
-		}
-
-		for i := range found.Spec.Template.Spec.Containers {
-			found.Spec.Template.Spec.Containers[i].Env = append(found.Spec.Template.Spec.Containers[i].Env, *envVar)
-		}
-
-		if err := api.Update(context.TODO(), found); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -247,7 +190,7 @@ func egress(u *unstructured.Unstructured) *unstructured.Unstructured {
 	return u
 }
 
-func ensureOpenShiftRegistryForConfigMap(u *unstructured.Unstructured) *unstructured.Unstructured {
+func openShiftRegistry(u *unstructured.Unstructured) *unstructured.Unstructured {
 	if u.GetKind() == "ConfigMap" && u.GetName() == "config-deployment" {
 		data := map[string]string{"registriesSkippingTagResolving": "ko.local,dev.local,docker-registry.default.svc:5000,image-registry.openshift-image-registry.svc:5000"}
 		common.UpdateConfigMap(u, data, log)
@@ -256,13 +199,50 @@ func ensureOpenShiftRegistryForConfigMap(u *unstructured.Unstructured) *unstruct
 	return u
 }
 
-func ensureConfigMapForCrt(instance *servingv1alpha1.Install) error {
-	cmName := "config-service-ca"
+func deploymentController(u *unstructured.Unstructured) *unstructured.Unstructured {
+	const volumeName = "service-ca"
+	if u.GetKind() == "Deployment" && u.GetName() == "controller" {
+
+		deploy := &appsv1.Deployment{}
+		scheme.Convert(u, deploy, nil)
+
+		volumes := deploy.Spec.Template.Spec.Volumes
+		for _, v := range volumes {
+			if v.Name == volumeName {
+				return u
+			}
+		}
+		deploy.Spec.Template.Spec.Volumes = append(volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: caBundleConfigMapName,
+					},
+				},
+			},
+		})
+
+		containers := deploy.Spec.Template.Spec.Containers
+		containers[0].VolumeMounts = append(containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      volumeName,
+			MountPath: "/var/run/secrets/kubernetes.io/servicecerts",
+		})
+		containers[0].Env = append(containers[0].Env, v1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/var/run/secrets/kubernetes.io/servicecerts/service-ca.crt",
+		})
+		scheme.Convert(deploy, u, nil)
+	}
+	return u
+}
+
+func caBundleConfigMap(instance *servingv1alpha1.Install) error {
 	cm := &v1.ConfigMap{}
-	if err := api.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: instance.GetNamespace()}, cm); err != nil {
+	if err := api.Get(context.TODO(), types.NamespacedName{Name: caBundleConfigMapName, Namespace: instance.GetNamespace()}, cm); err != nil {
 		if errors.IsNotFound(err) {
 			// Define a new configmap
-			cm.Name = cmName
+			cm.Name = caBundleConfigMapName
 			cm.Annotations = make(map[string]string)
 			cm.Annotations["service.alpha.openshift.io/inject-cabundle"] = "true"
 			cm.Namespace = instance.GetNamespace()


### PR DESCRIPTION
This works around a limitation of manifestival in which it's really
not smart enough to deal with merges of manifest specs and existing
resources. I think the right way to do it is to use patches, but those
aren't supported in an official release of controller-runtime yet.

This bug was revealed by https://github.com/openshift-knative/knative-serving-operator/pull/16 in which an infinite loop would occur when the operator was started up and an `Install` CR already existed.