### PR TITLE
Transformers now return errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -355,12 +355,12 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "newideas"
-  digest = "1:40185bb7a1d1360bb26a0702d98a16a11f2c332b5aa775fb13229e44228f6c4d"
+  branch = "master"
+  digest = "1:8fbf494bdf672fa8f092c54e69f6aff8472d8d4e408f88650ea12d0c400802ec"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "4c3370701b1e52aaa9af795c2c6b4a7e54518629"
+  revision = "52be0f85c9024ef6749526788e47ca4113e88654"
 
 [[projects]]
   digest = "1:da62aa6632d04e080b8a8b85a59ed9ed1550842a0099a55f3ae3a20d02a3745a"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -355,12 +355,12 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:77b62b256126cfbb7d62e6f8544212bb2c4a2cd87108a6c813e23aec3aada3dc"
+  branch = "newideas"
+  digest = "1:40185bb7a1d1360bb26a0702d98a16a11f2c332b5aa775fb13229e44228f6c4d"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "921da97b38a42f3dc6a58278cc6edb8955e02293"
+  revision = "4c3370701b1e52aaa9af795c2c6b4a7e54518629"
 
 [[projects]]
   digest = "1:da62aa6632d04e080b8a8b85a59ed9ed1550842a0099a55f3ae3a20d02a3745a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  branch = "master"
+  branch = "newideas"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  branch = "newideas"
+  branch = "master"
 
 [prune]
   go-tests = true

--- a/pkg/controller/install/common/extensions.go
+++ b/pkg/controller/install/common/extensions.go
@@ -42,13 +42,13 @@ func (exts Extensions) Transform(instance *servingv1alpha1.Install) []mf.Transfo
 		result = append(result, extension.Transformers...)
 	}
 	// Let any config in instance override everything else
-	return append(result, func(u *unstructured.Unstructured) *unstructured.Unstructured {
+	return append(result, func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "ConfigMap" {
 			if data, ok := instance.Spec.Config[u.GetName()[7:]]; ok {
 				UpdateConfigMap(u, data, log)
 			}
 		}
-		return u
+		return nil
 	})
 }
 

--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -155,14 +155,15 @@ func (r *ReconcileInstall) install(instance *servingv1alpha1.Install) error {
 	if err != nil {
 		return err
 	}
-	// Transform the manifestival resources
-	r.config.Transform(extensions.Transform(instance)...)
 
-	err = extensions.PreInstall(instance)
+	err = r.config.Transform(extensions.Transform(instance)...)
 	if err == nil {
-		err = r.config.ApplyAll()
+		err = extensions.PreInstall(instance)
 		if err == nil {
-			err = extensions.PostInstall(instance)
+			err = r.config.ApplyAll()
+			if err == nil {
+				err = extensions.PostInstall(instance)
+			}
 		}
 	}
 	if err != nil {

--- a/pkg/controller/install/minikube/minikube.go
+++ b/pkg/controller/install/minikube/minikube.go
@@ -34,12 +34,12 @@ func Configure(c client.Client, _ *runtime.Scheme) (*common.Extension, error) {
 	return &extension, nil
 }
 
-func egress(u *unstructured.Unstructured) *unstructured.Unstructured {
+func egress(u *unstructured.Unstructured) error {
 	if u.GetKind() == "ConfigMap" && u.GetName() == "config-network" {
 		data := map[string]string{
 			"istio.sidecar.includeOutboundIPRanges": "10.0.0.1/24",
 		}
 		common.UpdateConfigMap(u, data, log)
 	}
-	return u
+	return nil
 }

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -24,12 +24,10 @@ type Manifestival interface {
 	DeleteAll() error
 	// Deletes a particular resource
 	Delete(spec *unstructured.Unstructured) error
-	// Transforms the resources within a Manifest; returns itself
-	Transform(fns ...Transformer) *Manifest
-	// Returns a deep copy of the matching resource read from the file
-	Find(apiVersion string, kind string, name string) *unstructured.Unstructured
-	// Returns the resource fetched from the api server, nil if not found
+	// Returns a copy of the resource from the api server, nil if not found
 	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	// Transforms the resources within a Manifest
+	Transform(fns ...Transformer) error
 }
 
 type Manifest struct {
@@ -64,6 +62,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	}
 	if current == nil {
 		logResource("Creating", spec)
+		annotate(spec, "manifestival", resourceCreated)
 		if err = f.client.Create(context.TODO(), spec); err != nil {
 			return err
 		}
@@ -87,8 +86,10 @@ func (f *Manifest) DeleteAll() error {
 		a[left], a[right] = a[right], a[left]
 	}
 	for _, spec := range a {
-		if err := f.Delete(&spec); err != nil {
-			return err
+		if okToDelete(&spec) {
+			if err := f.Delete(&spec); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -123,21 +124,11 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 	return result, err
 }
 
-func (f *Manifest) Find(apiVersion string, kind string, name string) *unstructured.Unstructured {
-	for _, spec := range f.Resources {
-		if spec.GetAPIVersion() == apiVersion &&
-			spec.GetKind() == kind &&
-			spec.GetName() == name {
-			return spec.DeepCopy()
-		}
-	}
-	return nil
-}
-
 // We need to preserve the top-level target keys, specifically
 // 'metadata.resourceVersion', 'spec.clusterIP', and any existing
 // entries in a ConfigMap's 'data' field. So we only overwrite fields
 // set in our src resource.
+// TODO: Use Patch instead
 func UpdateChanged(src, tgt map[string]interface{}) bool {
 	changed := false
 	for k, v := range src {
@@ -162,3 +153,24 @@ func logResource(msg string, spec *unstructured.Unstructured) {
 	name := fmt.Sprintf("%s/%s", spec.GetNamespace(), spec.GetName())
 	log.Info(msg, "name", name, "type", spec.GroupVersionKind())
 }
+
+func annotate(spec *unstructured.Unstructured, key string, value string) {
+	annotations := spec.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[key] = value
+	spec.SetAnnotations(annotations)
+}
+
+func okToDelete(spec *unstructured.Unstructured) bool {
+	switch spec.GetKind() {
+	case "Namespace":
+		return spec.GetAnnotations()["manifestival"] == resourceCreated
+	}
+	return true
+}
+
+const (
+	resourceCreated = "new"
+)


### PR DESCRIPTION
Uses a manifestival branch in which `Transform` and the `Transformer` functions return errors instead of resources. The old return was a little weird, and only necessary to deal with `Namespace` resources, which are now dealt with through annotations.