### PR TITLE
Ensure we have a single KnativeServing resource [SRVKS-129]

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -356,11 +356,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8fbf494bdf672fa8f092c54e69f6aff8472d8d4e408f88650ea12d0c400802ec"
+  digest = "1:dae0138fbbe600485b882ba294d569d4b438f2ebfa9bd0c4572990d1fa3aa795"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "52be0f85c9024ef6749526788e47ca4113e88654"
+  revision = "c8f99ce4c2a29e0531817d4954a950c1daa4a352"
 
 [[projects]]
   digest = "1:da62aa6632d04e080b8a8b85a59ed9ed1550842a0099a55f3ae3a20d02a3745a"

--- a/deploy/olm-catalog/knative-serving-operator/0.6.0/knative-serving-operator.v0.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-serving-operator/0.6.0/knative-serving-operator.v0.6.0.clusterserviceversion.yaml
@@ -167,9 +167,9 @@ spec:
         serviceAccountName: knative-serving-operator
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
@@ -50,6 +50,13 @@ func (is *KnativeServingStatus) MarkInstallFailed(msg string) {
 		"Install failed with message: %s", msg)
 }
 
+func (is *KnativeServingStatus) MarkIgnored(msg string) {
+	conditions.Manage(is).MarkFalse(
+		InstallSucceeded,
+		"Ignored",
+		"Install not attempted: %s", msg)
+}
+
 func (is *KnativeServingStatus) MarkInstallSucceeded() {
 	conditions.Manage(is).MarkTrue(InstallSucceeded)
 }

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -63,7 +63,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	if current == nil {
 		logResource("Creating", spec)
 		annotate(spec, "manifestival", resourceCreated)
-		if err = f.client.Create(context.TODO(), spec); err != nil {
+		if err = f.client.Create(context.TODO(), spec.DeepCopy()); err != nil {
 			return err
 		}
 	} else {

--- a/vendor/github.com/jcrossley3/manifestival/yaml.go
+++ b/vendor/github.com/jcrossley3/manifestival/yaml.go
@@ -118,6 +118,9 @@ func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
 		if err != nil {
 			break
 		}
+		if len(out.Object) == 0 {
+			continue
+		}
 		objs = append(objs, out)
 	}
 	if err != io.EOF {


### PR DESCRIPTION
The operator will now stick a KnativeServing CR in knative-serving
when it starts up, so installation is immediate.

We monitor all namespaces for CR's now, so...
  $ operator-sdk up local --namespace=""

We moved the manifest creation to InjectClient to clean up some of the
init logic.

We addressed a bug in manifestival that resulted in optimisitic
locking errors.