### PR TITLE
Add serviceaccount to privileged scc

### DIFF
--- a/pkg/controller/knativeserving/openshift/openshift.go
+++ b/pkg/controller/knativeserving/openshift/openshift.go
@@ -35,8 +35,8 @@ const (
 
 var (
 	extension = common.Extension{
-		Transformers: []mf.Transformer{ingress, egress, deploymentController, addUserToSCC},
-		PreInstalls:  []common.Extender{ensureMaistra, caBundleConfigMap},
+		Transformers: []mf.Transformer{ingress, egress, deploymentController},
+		PreInstalls:  []common.Extender{ensureMaistra, caBundleConfigMap, addUserToSCC},
 		PostInstalls: []common.Extender{ensureOpenshiftIngress},
 	}
 	log    = logf.Log.WithName("openshift")
@@ -205,7 +205,7 @@ func egress(u *unstructured.Unstructured) error {
 	return nil
 }
 
-func addUserToSCC(u *unstructured.Unstructured) error {
+func addUserToSCC(instance *servingv1alpha1.KnativeServing) error {
 	scc := &unstructured.Unstructured{}
 	scc.SetAPIVersion("security.openshift.io/v1")
 	scc.SetKind("SecurityContextConstraints")

--- a/pkg/controller/knativeserving/openshift/openshift.go
+++ b/pkg/controller/knativeserving/openshift/openshift.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	servingv1alpha1 "github.com/openshift-knative/knative-serving-operator/pkg/apis/serving/v1alpha1"
@@ -25,11 +26,16 @@ const (
 	maistraOperatorNamespace     = "istio-operator"
 	maistraControlPlaneNamespace = "istio-system"
 	caBundleConfigMapName        = "config-service-ca"
+
+	// The SA are added to priviledged for injection of istio-proxy https://maistra.io/docs/getting_started/application-requirements/
+	// Relaxing security constraints is only necessary during the OpenShift Service Mesh Technology Preview phase (as per the docs).
+	serviceAccountName = "system:serviceaccount:knative-serving:controller"
+	sccName            = "privileged"
 )
 
 var (
 	extension = common.Extension{
-		Transformers: []mf.Transformer{ingress, egress, deploymentController},
+		Transformers: []mf.Transformer{ingress, egress, deploymentController, addUserToSCC},
 		PreInstalls:  []common.Extender{ensureMaistra, caBundleConfigMap},
 		PostInstalls: []common.Extender{ensureOpenshiftIngress},
 	}
@@ -196,6 +202,35 @@ func egress(u *unstructured.Unstructured) error {
 			common.UpdateConfigMap(u, data, log)
 		}
 	}
+	return nil
+}
+
+func addUserToSCC(u *unstructured.Unstructured) error {
+	scc := &unstructured.Unstructured{}
+	scc.SetAPIVersion("security.openshift.io/v1")
+	scc.SetKind("SecurityContextConstraints")
+
+	err := api.Get(context.TODO(), client.ObjectKey{Name: sccName}, scc)
+	if err != nil {
+		return err
+	}
+	// Verify if SA has already been assigned to the SCC
+	existing, exists, _ := unstructured.NestedStringSlice(scc.UnstructuredContent(), "users")
+	if exists {
+		for _, e := range existing {
+			if e == serviceAccountName {
+				return nil
+			}
+		}
+		existing = append(existing, serviceAccountName)
+	}
+
+	unstructured.SetNestedStringSlice(scc.UnstructuredContent(), existing, "users")
+	err = api.Update(context.TODO(), scc)
+	if err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("Added ServiceAccount %q to SecurityContextConstraints %q", serviceAccountName, sccName))
 	return nil
 }
 


### PR DESCRIPTION
When istio-proxy is injected, it needs to use privileged scc.

This patch adds function to add controller serviceaccount to the
privileged scc.

NOTE(or TODO):
- This patch does not remove serviceaccount which we added during
uninstallation.
- This patch adds `controller` serviceaccount to `privileged` scc, but
the `controller` serviceaccount is used by other pods in
`knative-serving` project. (Another SA should be used for `privileged` scc?)
- Maistra x OCP4.1 has a [known issue](https://issues.jboss.org/browse/MAISTRA-410).
