### PR TITLE
Add permission for RestrictedEndpointsAdmission

### DIFF
--- a/deploy/resources/knative-serving-0.6.0.yaml
+++ b/deploy/resources/knative-serving-0.6.0.yaml
@@ -94,6 +94,12 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - endpoints/restricted  # Permission for RestrictedEndpointsAdmission
+  verbs:
+  - create
+- apiGroups:
   - apps
   resources:
   - deployments


### PR DESCRIPTION
When RestrictedEndpointsAdmission is enabled, service endpoints are
not allowed to create from other namespace.
Since knative service's endpoints are same with `activator-service`'s
endpoints, it fails to create endpoints if cluster enabled
`RestrictedEndpointsAdmission`.

This patch adds permission `endpoints/restricted` into clusterrole for
address the problem.

Fixes https://jira.coreos.com/browse/SRVKS-143

cc @markusthoemmes 