### PR TITLE
Add permissions to the admin default roles

### DIFF
--- a/deploy/resources/knative-serving-0.6.0.yaml
+++ b/deploy/resources/knative-serving-0.6.0.yaml
@@ -173,6 +173,18 @@ rules:
   - watch
 
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: "v0.6.0"
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Currently even `admin` user in the project cannot access to knative
resources.
It is very painful, because cluster-admin always needs to add
the permissions to every project admins.

To solve it, this patch introduces `knative-serving-namespaced-admin`
role which has aggregated clusterroles to manipulate
`serving.knative.dev` resources by namespaced admin.

Fixes https://jira.coreos.com/browse/SRVKS-142