### PR TITLE
Use ubi7 image instead of ubi7-dev-preview

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 ENV OPERATOR=/usr/local/bin/knative-serving-operator \
     USER_UID=1001 \


### PR DESCRIPTION
This patch updates the image, since `ubi7-dev-preview` is obsoleted.