### PR TITLE
Enable platforms to filter resources and drop the custom-metrics APIService.

### DIFF
--- a/pkg/controller/knativeserving/common/extensions.go
+++ b/pkg/controller/knativeserving/common/extensions.go
@@ -13,9 +13,11 @@ var log = logf.Log.WithName("common")
 
 type Platforms []func(client.Client, *runtime.Scheme) (*Extension, error)
 type Extender func(*servingv1alpha1.KnativeServing) error
+type Filter func(*unstructured.Unstructured) bool
 type Extensions []Extension
 type Extension struct {
 	Transformers []mf.Transformer
+	Filters      []Filter
 	PreInstalls  []Extender
 	PostInstalls []Extender
 }
@@ -50,6 +52,14 @@ func (exts Extensions) Transform(instance *servingv1alpha1.KnativeServing) []mf.
 		}
 		return nil
 	})
+}
+
+func (exts Extensions) Filter(instance *servingv1alpha1.KnativeServing) []Filter {
+	var result []Filter
+	for _, extension := range exts {
+		result = append(result, extension.Filters...)
+	}
+	return result
 }
 
 func (exts Extensions) PreInstall(instance *servingv1alpha1.KnativeServing) error {

--- a/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/pkg/controller/knativeserving/knativeserving_controller.go
@@ -173,6 +173,20 @@ func (r *ReconcileKnativeServing) install(instance *servingv1alpha1.KnativeServi
 		return err
 	}
 
+	var filtered []unstructured.Unstructured
+	for _, resource := range r.config.Resources {
+		keep := true
+		for _, filter := range extensions.Filter(instance) {
+			if !filter(&resource) {
+				keep = false
+			}
+		}
+		if keep {
+			filtered = append(filtered, resource)
+		}
+	}
+	r.config.Resources = filtered
+
 	err = r.config.Transform(extensions.Transform(instance)...)
 	if err == nil {
 		err = extensions.PreInstall(instance)


### PR DESCRIPTION
Fixes SRVKS-210.

This enables each platform/plugin to define a number of filters which are applied to the list of read resources before we apply any transformers to them, let alone installing them. Effectively, this enables us to drop certain resources programmatically.

The APIService for the custom-metrics API is dropped for now to not trigger SRVKS-186 unnecessarily.