### PR TITLE
Add network policies.

### DIFF
--- a/deploy/resources/network/network_policies.yaml
+++ b/deploy/resources/network/network_policies.yaml
@@ -1,0 +1,83 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    app: webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: webhook
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: autoscaler
+  namespace: knative-serving
+  labels:
+    app: autoscaler
+spec:
+  podSelector:
+    matchLabels:
+      app: autoscaler
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    app: activator
+spec:
+  podSelector:
+    matchLabels:
+      app: activator
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    app: controller
+spec:
+  podSelector:
+    matchLabels:
+      app: controller
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: networking-certmanager
+  namespace: knative-serving
+  labels:
+    app: networking-certmanager
+spec:
+  podSelector:
+    matchLabels:
+      app: networking-certmanager
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: networking-istio
+  namespace: knative-serving
+  labels:
+    app: networking-istio
+spec:
+  podSelector:
+    matchLabels:
+      app: networking-istio
+  ingress:
+  - {}

--- a/pkg/controller/knativeserving/openshift/openshift.go
+++ b/pkg/controller/knativeserving/openshift/openshift.go
@@ -572,11 +572,11 @@ func installNetworkPolicies(instance *servingv1alpha1.KnativeServing) error {
 		transforms = append(transforms, mf.InjectNamespace(namespace))
 	}
 	if err := manifest.Transform(transforms...); err != nil {
-		log.Error(err, "Unable to transform service monitor manifest")
+		log.Error(err, "Unable to transform network policy manifest")
 		return err
 	}
 	if err := manifest.ApplyAll(); err != nil {
-		log.Error(err, "Unable to install ServiceMonitor")
+		log.Error(err, "Unable to install Network Policies")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fixes SRVKS-206

Newer ServiceMesh versions will tighten up the default network policy so we need to explictly tell it to allow traffic to flow into our controllers. In case of webhook, activator and autoscaler, traffic needs to be able to flow in for these components to actually work. For the remaining components, we want to be able to scrape metrics from them, so traffic needs to be allowed in as well.

In the future we could look at tightening those policies down even more, i.e. to only allow prometheus traffic to hit the controllers etc.