### PR TITLE
Ignore very low versions.

### DIFF
--- a/pkg/controller/knativeserving/openshift/openshift.go
+++ b/pkg/controller/knativeserving/openshift/openshift.go
@@ -105,6 +105,11 @@ func checkVersion(instance *servingv1alpha1.KnativeServing) error {
 		return err
 	}
 
+	if current.Major == 0 && current.Minor == 0 {
+		log.Info("CI build detected, bypassing version check")
+		return nil
+	}
+
 	if strings.Contains(string(current.PreRelease), "ci") ||
 		strings.Contains(string(current.PreRelease), "nightly") {
 		log.Info("CI/Nightly version detected, bypassing version check")


### PR DESCRIPTION
CI builds seem to have build versions like '0.0.1-2019-08-23-113428'. We can safely say that no such version is properly around and therefore disable the version check.