### PR TITLE
Backport SRVKS-270

### DIFF
--- a/deploy/resources/knative-serving-0.8.1.yaml
+++ b/deploy/resources/knative-serving-0.8.1.yaml
@@ -67,6 +67,32 @@ rules:
   - '*'
 
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:


### PR DESCRIPTION
This patch backport folloging commit to 1.1.0.

- https://github.com/knative/serving/commit/df65e57d6f3921e55463df1e2926f89a9d44b9c7

Fixes https://jira.coreos.com/browse/SRVKS-270