### PR TITLE
[SRVKS-281] Explicit RBAC resources for non-cluster admins

### DIFF
--- a/deploy/resources/knative-serving-0.9.0.yaml
+++ b/deploy/resources/knative-serving-0.9.0.yaml
@@ -57,15 +57,9 @@ metadata:
     serving.knative.dev/release: "v0.9.0"
   name: knative-serving-namespaced-admin
 rules:
-- apiGroups:
-  - serving.knative.dev
-  - networking.internal.knative.dev
-  - autoscaling.internal.knative.dev
-  resources:
-  - '*'
-  verbs:
-  - '*'
-
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+    verbs: ["*"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,7 +70,7 @@ metadata:
     serving.knative.dev/release: "v0.9.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["*"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
     verbs: ["create", "update", "patch", "delete"]
 
 ---
@@ -89,7 +83,7 @@ metadata:
     serving.knative.dev/release: "v0.9.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["*"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
     verbs: ["get", "list", "watch"]
 ---
 


### PR DESCRIPTION
As per title, this patch defines RBAC resources explicitly instead of `"*"`.

This is a workaround until [SRVKS-308](https://jira.coreos.com/browse/SRVKS-308) is addressed.