### PR TITLE
handle separately MutatingWebhookConfiguration and ValidatingWebhookConfiguration and add changes for knative 0.10.0 release

### DIFF
--- a/deploy/olm-catalog/knative-serving-operator/knative-serving-operator.package.yaml
+++ b/deploy/olm-catalog/knative-serving-operator/knative-serving-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: knative-serving-operator.v0.9.0
+- currentCSV: knative-serving-operator.v0.10.0
   name: alpha
 defaultChannel: alpha
 packageName: knative-serving-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,16 +33,16 @@ spec:
             - name: OPERATOR_NAME
               value: "knative-serving-operator"
             - name: IMAGE_QUEUE
-              value: quay.io/openshift-knative/knative-serving-queue:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-queue:v0.10.0
             - name: IMAGE_activator
-              value: quay.io/openshift-knative/knative-serving-activator:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-activator:v0.10.0
             - name: IMAGE_autoscaler
-              value: quay.io/openshift-knative/knative-serving-autoscaler:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-autoscaler:v0.10.0
             - name: IMAGE_autoscaler-hpa
-              value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.10.0
             - name: IMAGE_controller
-              value: quay.io/openshift-knative/knative-serving-controller:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-controller:v0.10.0
             - name: IMAGE_networking-istio
-              value: quay.io/openshift-knative/knative-serving-istio:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-istio:v0.10.0
             - name: IMAGE_webhook
-              value: quay.io/openshift-knative/knative-serving-webhook:v0.9.0
+              value: quay.io/openshift-knative/knative-serving-webhook:v0.10.0

--- a/deploy/resources/knative-serving-0.10.0.yaml
+++ b/deploy/resources/knative-serving-0.10.0.yaml
@@ -1776,6 +1776,25 @@ spec:
         number: 80
         protocol: HTTP
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: "v0.10.0"
+  name: cluster-local-gateway
+  namespace: knative-serving
+spec:
+  selector:
+    istio: cluster-local-gateway
+  servers:
+    - hosts:
+        - '*'
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
+---
 apiVersion: v1
 data:
   _example: |

--- a/deploy/resources/knative-serving-0.10.0.yaml
+++ b/deploy/resources/knative-serving-0.10.0.yaml
@@ -5,6 +5,11 @@ metadata:
     istio-injection: enabled
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving
+
+---
+
+---
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -14,12 +19,13 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: custom-metrics-server-resources
 rules:
-  - apiGroups:
-      - custom.metrics.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29,9 +35,9 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-admin
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["*"]
+- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -41,9 +47,9 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-edit
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+  verbs: ["create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -53,14 +59,15 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-view
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["get", "list", "watch"]
+- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+  resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+  verbs: ["get", "list", "watch"]
+
 ---
 aggregationRule:
   clusterRoleSelectors:
-    - matchLabels:
-        serving.knative.dev/controller: "true"
+  - matchLabels:
+      serving.knative.dev/controller: "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -77,110 +84,110 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-core
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - namespaces
-      - secrets
-      - configmaps
-      - endpoints
-      - services
-      - events
-      - serviceaccounts
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints/restricted
-    verbs:
-      - create
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - deployments/finalizers
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - serving.knative.dev
-      - autoscaling.internal.knative.dev
-      - networking.internal.knative.dev
-    resources:
-      - '*'
-      - '*/status'
-      - '*/finalizers'
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - deletecollection
-      - patch
-      - watch
-  - apiGroups:
-      - caching.internal.knative.dev
-    resources:
-      - images
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - secrets
+  - configmaps
+  - endpoints
+  - services
+  - events
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/restricted
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - serving.knative.dev
+  - autoscaling.internal.knative.dev
+  - networking.internal.knative.dev
+  resources:
+  - '*'
+  - '*/status'
+  - '*/finalizers'
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - caching.internal.knative.dev
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 
 ---
 apiVersion: v1
@@ -204,9 +211,9 @@ roleRef:
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
-  - kind: ServiceAccount
-    name: controller
-    namespace: knative-serving
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -221,9 +228,9 @@ roleRef:
   kind: ClusterRole
   name: custom-metrics-server-resources
 subjects:
-  - kind: ServiceAccount
-    name: horizontal-pod-autoscaler
-    namespace: kube-system
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -237,9 +244,9 @@ roleRef:
   kind: ClusterRole
   name: knative-serving-admin
 subjects:
-  - kind: ServiceAccount
-    name: controller
-    namespace: knative-serving
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -255,9 +262,14 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
-  - kind: ServiceAccount
-    name: controller
-    namespace: knative-serving
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+
+---
+
+---
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -268,21 +280,21 @@ metadata:
   name: certificates.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
   group: networking.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - networking
+    - knative-internal
+    - networking
     kind: Certificate
     plural: certificates
     shortNames:
-      - kcert
+    - kcert
     singular: certificate
   scope: Namespaced
   subresources:
@@ -299,43 +311,43 @@ metadata:
   name: configurations.serving.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.latestCreatedRevisionName
-      name: LatestCreated
-      type: string
-    - JSONPath: .status.latestReadyRevisionName
-      name: LatestReady
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: serving.knative.dev
   names:
     categories:
-      - all
-      - knative
-      - serving
+    - all
+    - knative
+    - serving
     kind: Configuration
     plural: configurations
     shortNames:
-      - config
-      - cfg
+    - config
+    - cfg
     singular: configuration
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1
-      served: true
-      storage: false
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -348,12 +360,12 @@ spec:
   group: caching.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - caching
+    - knative-internal
+    - caching
     kind: Image
     plural: images
     shortNames:
-      - img
+    - img
     singular: image
   scope: Namespaced
   subresources:
@@ -370,29 +382,29 @@ metadata:
   name: ingresses.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: networking.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - networking
+    - knative-internal
+    - networking
     kind: Ingress
     plural: ingresses
     shortNames:
-      - ing
+    - ing
     singular: ingress
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -404,17 +416,17 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: autoscaling.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - autoscaling
+    - knative-internal
+    - autoscaling
     kind: Metric
     plural: metrics
     singular: metric
@@ -433,36 +445,36 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.desiredScale
-      name: DesiredScale
-      type: integer
-    - JSONPath: .status.actualScale
-      name: ActualScale
-      type: integer
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.desiredScale
+    name: DesiredScale
+    type: integer
+  - JSONPath: .status.actualScale
+    name: ActualScale
+    type: integer
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: autoscaling.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - autoscaling
+    - knative-internal
+    - autoscaling
     kind: PodAutoscaler
     plural: podautoscalers
     shortNames:
-      - kpa
-      - pa
+    - kpa
+    - pa
     singular: podautoscaler
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -474,45 +486,45 @@ metadata:
   name: revisions.serving.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
-      name: Config Name
-      type: string
-    - JSONPath: .status.serviceName
-      name: K8s Service Name
-      type: string
-    - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
-      name: Generation
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
+    name: Config Name
+    type: string
+  - JSONPath: .status.serviceName
+    name: K8s Service Name
+    type: string
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+    name: Generation
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: serving.knative.dev
   names:
     categories:
-      - all
-      - knative
-      - serving
+    - all
+    - knative
+    - serving
     kind: Revision
     plural: revisions
     shortNames:
-      - rev
+    - rev
     singular: revision
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1
-      served: true
-      storage: false
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -525,39 +537,39 @@ metadata:
   name: routes.serving.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.url
-      name: URL
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: serving.knative.dev
   names:
     categories:
-      - all
-      - knative
-      - serving
+    - all
+    - knative
+    - serving
     kind: Route
     plural: routes
     shortNames:
-      - rt
+    - rt
     singular: route
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1
-      served: true
-      storage: false
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -570,46 +582,46 @@ metadata:
   name: services.serving.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.url
-      name: URL
-      type: string
-    - JSONPath: .status.latestCreatedRevisionName
-      name: LatestCreated
-      type: string
-    - JSONPath: .status.latestReadyRevisionName
-      name: LatestReady
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: serving.knative.dev
   names:
     categories:
-      - all
-      - knative
-      - serving
+    - all
+    - knative
+    - serving
     kind: Service
     plural: services
     shortNames:
-      - kservice
-      - ksvc
+    - kservice
+    - ksvc
     singular: service
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1
-      served: true
-      storage: false
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -621,38 +633,38 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-    - JSONPath: .spec.mode
-      name: Mode
-      type: string
-    - JSONPath: .status.serviceName
-      name: ServiceName
-      type: string
-    - JSONPath: .status.privateServiceName
-      name: PrivateServiceName
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
+  - JSONPath: .spec.mode
+    name: Mode
+    type: string
+  - JSONPath: .status.serviceName
+    name: ServiceName
+    type: string
+  - JSONPath: .status.privateServiceName
+    name: PrivateServiceName
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
   group: networking.internal.knative.dev
   names:
     categories:
-      - knative-internal
-      - networking
+    - knative-internal
+    - networking
     kind: ServerlessService
     plural: serverlessservices
     shortNames:
-      - sks
+    - sks
     singular: serverlessservice
   scope: Namespaced
   subresources:
     status: {}
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 
 ---
 apiVersion: v1
@@ -665,18 +677,18 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: 8012
-    - name: http2
-      port: 81
-      protocol: TCP
-      targetPort: 8013
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8012
+  - name: http2
+    port: 81
+    protocol: TCP
+    targetPort: 8013
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: activator
   type: ClusterIP
@@ -692,10 +704,10 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: controller
 
@@ -710,8 +722,8 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - port: 443
-      targetPort: 8443
+  - port: 443
+    targetPort: 8443
   selector:
     role: webhook
 ---
@@ -749,59 +761,59 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/internal/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:0c52e0a85612bbedebf6d0de2b1951a4f762a05691f86e78079a5089d4848652
-          livenessProbe:
-            httpGet:
-              httpHeaders:
-                - name: k-kubelet-probe
-                  value: activator
-              path: /healthz
-              port: 8012
-          name: activator
-          ports:
-            - containerPort: 8012
-              name: http1
-            - containerPort: 8013
-              name: h2c
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: k-kubelet-probe
-                  value: activator
-              path: /healthz
-              port: 8012
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 600Mi
-            requests:
-              cpu: 300m
-              memory: 60Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:0c52e0a85612bbedebf6d0de2b1951a4f762a05691f86e78079a5089d4848652
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        name: activator
+        ports:
+        - containerPort: 8012
+          name: http1
+        - containerPort: 8013
+          name: h2c
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 300m
+            memory: 60Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
       terminationGracePeriodSeconds: 300
 ---
@@ -813,10 +825,10 @@ metadata:
 spec:
   maxReplicas: 20
   metrics:
-    - resource:
-        name: cpu
-        targetAverageUtilization: 100
-      type: Resource
+  - resource:
+      name: cpu
+      targetAverageUtilization: 100
+    type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
@@ -846,33 +858,33 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:f5514430997ed3799e0f708d657fef935e7eef2774f073a46ffb06311c8b5e76
-          name: autoscaler-hpa
-          ports:
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:f5514430997ed3799e0f708d657fef935e7eef2774f073a46ffb06311c8b5e76
+        name: autoscaler-hpa
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -886,18 +898,18 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - name: http
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
-    - name: custom-metrics
-      port: 443
-      protocol: TCP
-      targetPort: 8443
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: custom-metrics
+    port: 443
+    protocol: TCP
+    targetPort: 8443
   selector:
     app: autoscaler
 
@@ -925,54 +937,54 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - args:
-            - --secure-port=8443
-            - --cert-dir=/tmp
-          env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:9b716bec384c166782f30756e0981ab11178e1a6b7a4fa6965cc6225abf8567c
-          livenessProbe:
-            httpGet:
-              httpHeaders:
-                - name: k-kubelet-probe
-                  value: autoscaler
-              path: /healthz
-              port: 8080
-          name: autoscaler
-          ports:
-            - containerPort: 8080
-              name: websocket
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8443
-              name: custom-metrics
-            - containerPort: 8008
-              name: profiling
-          readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: k-kubelet-probe
-                  value: autoscaler
-              path: /healthz
-              port: 8080
-          resources:
-            limits:
-              cpu: 300m
-              memory: 400Mi
-            requests:
-              cpu: 30m
-              memory: 40Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - args:
+        - --secure-port=8443
+        - --cert-dir=/tmp
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:9b716bec384c166782f30756e0981ab11178e1a6b7a4fa6965cc6225abf8567c
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        name: autoscaler
+        ports:
+        - containerPort: 8080
+          name: websocket
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8443
+          name: custom-metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        resources:
+          limits:
+            cpu: 300m
+            memory: 400Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -1634,33 +1646,33 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/internal/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:a168c9fa095c88b3e0bcbbaa6d4501a8a02ab740b360938879ae9df55964a758
-          name: controller
-          ports:
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:a168c9fa095c88b3e0bcbbaa6d4501a8a02ab740b360938879ae9df55964a758
+        name: controller
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -1680,6 +1692,13 @@ spec:
     namespace: knative-serving
   version: v1beta1
   versionPriority: 100
+
+---
+
+---
+
+---
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1705,34 +1724,39 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:f59e8d9782f17b1af3060152d99b70ae08f40aa69b799180d24964e527ebb818
-          name: webhook
-          ports:
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 20m
-              memory: 20Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:f59e8d9782f17b1af3060152d99b70ae08f40aa69b799180d24964e527ebb818
+        name: webhook
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 20m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
+
+---
+
+---
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1743,19 +1767,36 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-istio
 rules:
-  - apiGroups:
-      - networking.istio.io
-    resources:
-      - virtualservices
-      - gateways
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - gateways
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -1769,12 +1810,13 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-    - hosts:
-        - '*'
-      port:
-        name: http
-        number: 80
-        protocol: HTTP
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -1788,12 +1830,63 @@ spec:
   selector:
     istio: cluster-local-gateway
   servers:
-    - hosts:
-        - '*'
-      port:
-        name: http
-        number: 80
-        protocol: HTTP
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
 ---
 apiVersion: v1
 data:
@@ -1844,6 +1937,21 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: config-istio
   namespace: knative-serving
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1867,31 +1975,37 @@ spec:
         serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-        - env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:4bc49ca99adf8e4f5c498bdd1287cdf643e4b721e69b2c4a022fe98db46486ff
-          name: networking-istio
-          ports:
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          securityContext:
-            allowPrivilegeEscalation: false
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:4bc49ca99adf8e4f5c498bdd1287cdf643e4b721e69b2c4a022fe98db46486ff
+        name: networking-istio
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: controller
+
+---
+
+---
+
+---

--- a/deploy/resources/knative-serving-0.10.0.yaml
+++ b/deploy/resources/knative-serving-0.10.0.yaml
@@ -29,15 +29,9 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-admin
 rules:
-  - apiGroups:
-      - serving.knative.dev
-      - networking.internal.knative.dev
-      - autoscaling.internal.knative.dev
-      - caching.internal.knative.dev
-    resources:
-      - '*'
-    verbs:
-      - '*'
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -47,17 +41,9 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-edit
 rules:
-  - apiGroups:
-      - serving.knative.dev
-      - networking.internal.knative.dev
-      - autoscaling.internal.knative.dev
-    resources:
-      - '*'
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+    verbs: ["create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -67,17 +53,9 @@ metadata:
     serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-view
 rules:
-  - apiGroups:
-      - serving.knative.dev
-      - networking.internal.knative.dev
-      - autoscaling.internal.knative.dev
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
+    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
+    verbs: ["get", "list", "watch"]
 ---
 aggregationRule:
   clusterRoleSelectors:

--- a/deploy/resources/knative-serving-0.10.0.yaml
+++ b/deploy/resources/knative-serving-0.10.0.yaml
@@ -3,99 +3,91 @@ kind: Namespace
 metadata:
   labels:
     istio-injection: enabled
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: knative-serving
-
----
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: knative-serving-istio
-rules:
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - virtualservices
-  - gateways
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: custom-metrics-server-resources
 rules:
-- apiGroups:
-  - custom.metrics.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-
+  - apiGroups:
+      - custom.metrics.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: knative-serving-namespaced-admin
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["*"]
+  - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+      - caching.internal.knative.dev
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
+  name: knative-serving-namespaced-edit
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["create", "update", "patch", "delete"]
-
+  - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+    resources:
+      - '*'
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
+  name: knative-serving-namespaced-view
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev"]
-    resources: ["certificates", "configurations", "images", "ingresses", "metrics", "podautoscalers", "revisions", "routes", "serverlessservices", "services"] # Use "*" once SRVKS-308 is solved.
-    verbs: ["get", "list", "watch"]
----
+  - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 
+---
 aggregationRule:
   clusterRoleSelectors:
-  - matchLabels:
-      serving.knative.dev/controller: "true"
+    - matchLabels:
+        serving.knative.dev/controller: "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: knative-serving-admin
 rules: []
 ---
@@ -104,119 +96,120 @@ kind: ClusterRole
 metadata:
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: knative-serving-core
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  - secrets
-  - configmaps
-  - endpoints
-  - services
-  - events
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints/restricted
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/finalizers
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - serving.knative.dev
-  - autoscaling.internal.knative.dev
-  - networking.internal.knative.dev
-  resources:
-  - '*'
-  - '*/status'
-  - '*/finalizers'
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - deletecollection
-  - patch
-  - watch
-- apiGroups:
-  - caching.internal.knative.dev
-  resources:
-  - images
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      - secrets
+      - configmaps
+      - endpoints
+      - services
+      - events
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints/restricted
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - serving.knative.dev
+      - autoscaling.internal.knative.dev
+      - networking.internal.knative.dev
+    resources:
+      - '*'
+      - '*/status'
+      - '*/finalizers'
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - patch
+      - watch
+  - apiGroups:
+      - caching.internal.knative.dev
+    resources:
+      - images
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: controller
   namespace: knative-serving
 
@@ -226,16 +219,16 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: custom-metrics:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
-- kind: ServiceAccount
-  name: controller
-  namespace: knative-serving
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -243,32 +236,32 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: hpa-controller-custom-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: custom-metrics-server-resources
 subjects:
-- kind: ServiceAccount
-  name: horizontal-pod-autoscaler
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: horizontal-pod-autoscaler
+    namespace: kube-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: knative-serving-controller-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: knative-serving-admin
 subjects:
-- kind: ServiceAccount
-  name: controller
-  namespace: knative-serving
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -276,7 +269,7 @@ kind: RoleBinding
 metadata:
   labels:
     autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: custom-metrics-auth-reader
   namespace: kube-system
 roleRef:
@@ -284,75 +277,34 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
-- kind: ServiceAccount
-  name: controller
-  namespace: knative-serving
-
----
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  labels:
-    networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.9.0"
-  name: knative-ingress-gateway
-  namespace: knative-serving
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - '*'
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
-
----
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  labels:
-    networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.9.0"
-  name: cluster-local-gateway
-  namespace: knative-serving
-spec:
-  selector:
-    istio: cluster-local-gateway
-  servers:
-  - hosts:
-    - '*'
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
-
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: certificates.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
-    name: Reason
-    type: string
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
   group: networking.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - networking
+      - knative-internal
+      - networking
     kind: Certificate
     plural: certificates
     shortNames:
-    - kcert
+      - kcert
     singular: certificate
   scope: Namespaced
   subresources:
@@ -365,31 +317,47 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: clusteringresses.networking.internal.knative.dev
+    serving.knative.dev/release: "v0.10.0"
+  name: configurations.serving.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
-  group: networking.internal.knative.dev
+    - JSONPath: .status.latestCreatedRevisionName
+      name: LatestCreated
+      type: string
+    - JSONPath: .status.latestReadyRevisionName
+      name: LatestReady
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+  group: serving.knative.dev
   names:
     categories:
-    - knative-internal
-    - networking
-    kind: ClusterIngress
-    plural: clusteringresses
-    singular: clusteringress
-  scope: Cluster
+      - all
+      - knative
+      - serving
+    kind: Configuration
+    plural: configurations
+    shortNames:
+      - config
+      - cfg
+    singular: configuration
+  scope: Namespaced
   subresources:
     status: {}
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -402,12 +370,12 @@ spec:
   group: caching.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - caching
+      - knative-internal
+      - caching
     kind: Image
     plural: images
     shortNames:
-    - img
+      - img
     singular: image
   scope: Namespaced
   subresources:
@@ -420,33 +388,33 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: ingresses.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
   group: networking.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - networking
+      - knative-internal
+      - networking
     kind: Ingress
     plural: ingresses
     shortNames:
-    - ing
+      - ing
     singular: ingress
   scope: Namespaced
   subresources:
     status: {}
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -454,21 +422,21 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: metrics.autoscaling.internal.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
   group: autoscaling.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - autoscaling
+      - knative-internal
+      - autoscaling
     kind: Metric
     plural: metrics
     singular: metric
@@ -483,40 +451,40 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: podautoscalers.autoscaling.internal.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.desiredScale
-    name: DesiredScale
-    type: integer
-  - JSONPath: .status.actualScale
-    name: ActualScale
-    type: integer
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
+    - JSONPath: .status.desiredScale
+      name: DesiredScale
+      type: integer
+    - JSONPath: .status.actualScale
+      name: ActualScale
+      type: integer
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
   group: autoscaling.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - autoscaling
+      - knative-internal
+      - autoscaling
     kind: PodAutoscaler
     plural: podautoscalers
     shortNames:
-    - kpa
-    - pa
+      - kpa
+      - pa
     singular: podautoscaler
   scope: Namespaced
   subresources:
     status: {}
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -524,42 +492,189 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
+  name: revisions.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
+      name: Config Name
+      type: string
+    - JSONPath: .status.serviceName
+      name: K8s Service Name
+      type: string
+    - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+      name: Generation
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+  group: serving.knative.dev
+  names:
+    categories:
+      - all
+      - knative
+      - serving
+    kind: Revision
+    plural: revisions
+    shortNames:
+      - rev
+    singular: revision
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: false
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    duck.knative.dev/addressable: "true"
+    knative.dev/crd-install: "true"
+    serving.knative.dev/release: "v0.10.0"
+  name: routes.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.url
+      name: URL
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+  group: serving.knative.dev
+  names:
+    categories:
+      - all
+      - knative
+      - serving
+    kind: Route
+    plural: routes
+    shortNames:
+      - rt
+    singular: route
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: false
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    duck.knative.dev/addressable: "true"
+    knative.dev/crd-install: "true"
+    serving.knative.dev/release: "v0.10.0"
+  name: services.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.url
+      name: URL
+      type: string
+    - JSONPath: .status.latestCreatedRevisionName
+      name: LatestCreated
+      type: string
+    - JSONPath: .status.latestReadyRevisionName
+      name: LatestReady
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+  group: serving.knative.dev
+  names:
+    categories:
+      - all
+      - knative
+      - serving
+    kind: Service
+    plural: services
+    shortNames:
+      - kservice
+      - ksvc
+    singular: service
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: false
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    knative.dev/crd-install: "true"
+    serving.knative.dev/release: "v0.10.0"
   name: serverlessservices.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.mode
-    name: Mode
-    type: string
-  - JSONPath: .status.serviceName
-    name: ServiceName
-    type: string
-  - JSONPath: .status.privateServiceName
-    name: PrivateServiceName
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
+    - JSONPath: .spec.mode
+      name: Mode
+      type: string
+    - JSONPath: .status.serviceName
+      name: ServiceName
+      type: string
+    - JSONPath: .status.privateServiceName
+      name: PrivateServiceName
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
   group: networking.internal.knative.dev
   names:
     categories:
-    - knative-internal
-    - networking
+      - knative-internal
+      - networking
     kind: ServerlessService
     plural: serverlessservices
     shortNames:
-    - sks
+      - sks
     singular: serverlessservice
   scope: Namespaced
   subresources:
     status: {}
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 
 ---
 apiVersion: v1
@@ -567,23 +682,23 @@ kind: Service
 metadata:
   labels:
     app: activator
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: activator-service
   namespace: knative-serving
 spec:
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 8012
-  - name: http2
-    port: 81
-    protocol: TCP
-    targetPort: 8013
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8012
+    - name: http2
+      port: 81
+      protocol: TCP
+      targetPort: 8013
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
   selector:
     app: activator
   type: ClusterIP
@@ -594,15 +709,15 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: controller
   namespace: knative-serving
 spec:
   ports:
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
   selector:
     app: controller
 
@@ -612,33 +727,32 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: webhook
   namespace: knative-serving
 spec:
   ports:
-  - port: 443
-    targetPort: 8443
+    - port: 443
+      targetPort: 8443
   selector:
     role: webhook
-
 ---
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: queue-proxy
   namespace: knative-serving
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:9ee46b5f0bd5d3a3dc7af319dafb79e88e18092bd1af6ff835b762fc12ba642a
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:5ff357b66622c98f24c56bba0a866be5e097306b83c5e6c41c28b6e87ec64c7c
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: activator
   namespace: knative-serving
 spec:
@@ -654,61 +768,62 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.9.0"
+        serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-      - args:
-        - -logtostderr=false
-        - -stderrthreshold=FATAL
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:0afc012397557e59991af44660e4729de524368d5e2dda01c8f9d0622f5a90d7
-        livenessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: activator
-            path: /healthz
-            port: 8012
-        name: activator
-        ports:
-        - containerPort: 8012
-          name: http1
-        - containerPort: 8013
-          name: h2c
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        readinessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: activator
-            path: /healthz
-            port: 8012
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 600Mi
-          requests:
-            cpu: 300m
-            memory: 60Mi
-        securityContext:
-          allowPrivilegeEscalation: false
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:0c52e0a85612bbedebf6d0de2b1951a4f762a05691f86e78079a5089d4848652
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: activator
+              path: /healthz
+              port: 8012
+          name: activator
+          ports:
+            - containerPort: 8012
+              name: http1
+            - containerPort: 8013
+              name: h2c
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: activator
+              path: /healthz
+              port: 8012
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 600Mi
+            requests:
+              cpu: 300m
+              memory: 60Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       serviceAccountName: controller
       terminationGracePeriodSeconds: 300
 ---
@@ -720,10 +835,10 @@ metadata:
 spec:
   maxReplicas: 20
   metrics:
-  - resource:
-      name: cpu
-      targetAverageUtilization: 100
-    type: Resource
+    - resource:
+        name: cpu
+        targetAverageUtilization: 100
+      type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
@@ -736,7 +851,7 @@ kind: Deployment
 metadata:
   labels:
     autoscaling.knative.dev/autoscaler-provider: hpa
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: autoscaler-hpa
   namespace: knative-serving
 spec:
@@ -750,36 +865,36 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.9.0"
+        serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-      - env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:3f3c381fe9e3d372f258f6d3e8fad89ad1c7d572d07625a759bce85ff718501a
-        name: autoscaler-hpa
-        ports:
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        securityContext:
-          allowPrivilegeEscalation: false
+        - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:f5514430997ed3799e0f708d657fef935e7eef2774f073a46ffb06311c8b5e76
+          name: autoscaler-hpa
+          ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -788,23 +903,23 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: autoscaler
   namespace: knative-serving
 spec:
   ports:
-  - name: http
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
-  - name: custom-metrics
-    port: 443
-    protocol: TCP
-    targetPort: 8443
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+    - name: custom-metrics
+      port: 443
+      protocol: TCP
+      targetPort: 8443
   selector:
     app: autoscaler
 
@@ -813,7 +928,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -829,57 +944,57 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: 8080,9090
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.9.0"
+        serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-      - args:
-        - --secure-port=8443
-        - --cert-dir=/tmp
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:5875e715093c646c283399baf191f8df801509f755f25f22d2c1e1900ee2838b
-        livenessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: autoscaler
-            path: /healthz
-            port: 8080
-        name: autoscaler
-        ports:
-        - containerPort: 8080
-          name: websocket
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8443
-          name: custom-metrics
-        - containerPort: 8008
-          name: profiling
-        readinessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: autoscaler
-            path: /healthz
-            port: 8080
-        resources:
-          limits:
-            cpu: 300m
-            memory: 400Mi
-          requests:
-            cpu: 30m
-            memory: 40Mi
-        securityContext:
-          allowPrivilegeEscalation: false
+        - args:
+            - --secure-port=8443
+            - --cert-dir=/tmp
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:9b716bec384c166782f30756e0981ab11178e1a6b7a4fa6965cc6225abf8567c
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: autoscaler
+              path: /healthz
+              port: 8080
+          name: autoscaler
+          ports:
+            - containerPort: 8080
+              name: websocket
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8443
+              name: custom-metrics
+            - containerPort: 8008
+              name: profiling
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: autoscaler
+              path: /healthz
+              port: 8080
+          resources:
+            limits:
+              cpu: 300m
+              memory: 400Mi
+            requests:
+              cpu: 30m
+              memory: 40Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -1000,7 +1115,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-autoscaler
   namespace: knative-serving
 
@@ -1072,7 +1187,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-defaults
   namespace: knative-serving
 
@@ -1097,11 +1212,11 @@ data:
 
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "ko.local,dev.local"
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:9ee46b5f0bd5d3a3dc7af319dafb79e88e18092bd1af6ff835b762fc12ba642a
+  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:5ff357b66622c98f24c56bba0a866be5e097306b83c5e6c41c28b6e87ec64c7c
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-deployment
   namespace: knative-serving
 
@@ -1147,7 +1262,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-domain
   namespace: knative-serving
 
@@ -1186,60 +1301,11 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-gc
   namespace: knative-serving
 
 ---
-apiVersion: v1
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # Default Knative Gateway after v0.3. It points to the Istio
-    # standard istio-ingressgateway, instead of a custom one that we
-    # used pre-0.3.
-    gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-
-    # A cluster local gateway to allow pods outside of the mesh to access
-    # Services and Routes not exposing through an ingress.  If the users
-    # do have a service mesh setup, this isn't required and can be removed.
-    #
-    # An example use case is when users want to use Istio without any
-    # sidecar injection (like Knative's istio-lean.yaml).  Since every pod
-    # is outside of the service mesh in that case, a cluster-local  service
-    # will need to be exposed to a cluster-local gateway to be accessible.
-    local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
-
-    # To use only Istio service mesh and no cluster-local-gateway, replace
-    # all local-gateway.* entries the following entry.
-    local-gateway.mesh: "mesh"
-
-    # Feature flag to enable reconciling external Istio Gateways.
-    # When auto TLS feature is turned on, reconcileExternalGateway will be automatically enforced.
-    # 1. true: enabling reconciling external gateways.
-    # 2. false: disabling reconciling external gateways.
-    reconcileExternalGateway: "false"
-kind: ConfigMap
-metadata:
-  labels:
-    networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.9.0"
-  name: config-istio
-  namespace: knative-serving
 
 ---
 apiVersion: v1
@@ -1295,7 +1361,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-logging
   namespace: knative-serving
 
@@ -1355,16 +1421,19 @@ data:
     #
     istio.sidecar.includeOutboundIPRanges: "*"
 
-    # clusteringress.class specifies the default cluster ingress class
+    # clusteringress.class has been deprecated.   Please use ingress.class instead.
+    clusteringress.class: "istio.ingress.networking.knative.dev"
+
+    # ingress.class specifies the default ingress class
     # to use when not dictated by Route annotation.
     #
     # If not specified, will use the Istio ingress.
     #
-    # Note that changing the ClusterIngress class of an existing Route
+    # Note that changing the Ingress class of an existing Route
     # will result in undefined behavior.  Therefore it is best to only
     # update this value during the setup of Knative, to avoid getting
     # undefined behavior.
-    clusteringress.class: "istio.ingress.networking.knative.dev"
+    ingress.class: "istio.ingress.networking.knative.dev"
 
     # certificate.class specifies the default Certificate class
     # to use when not dictated by Route annotation.
@@ -1418,7 +1487,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-network
   namespace: knative-serving
 
@@ -1444,7 +1513,7 @@ data:
     # logging.enable-var-log-collection defaults to false.
     # The fluentd daemon set will be set up to collect /var/log if
     # this flag is true.
-    logging.enable-var-log-collection: false
+    logging.enable-var-log-collection: "false"
 
     # logging.revision-url-template provides a template to use for producing the
     # logging URL that is injected into the status of each Revision.
@@ -1453,7 +1522,8 @@ data:
     logging.revision-url-template: |
       http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
 
-    # If non-empty, this enables queue proxy writing request logs to stdout.
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
     # The value determines the shape of the request logs and it must be a valid go text/template.
     # It is important to keep this as a single line. Multiple lines are parsed as separate entities
     # by most collection agents and will split the request logs into multiple records.
@@ -1481,6 +1551,10 @@ data:
     # }
     #
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
 
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.
@@ -1512,7 +1586,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-observability
   namespace: knative-serving
 
@@ -1556,7 +1630,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: config-tracing
   namespace: knative-serving
 
@@ -1565,7 +1639,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -1579,36 +1653,36 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.9.0"
+        serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-      - env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:80173e32cc7111b6d92f85530cf9e933ee2e8f4cbafe6412df486e53fa1b5479
-        name: controller
-        ports:
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        securityContext:
-          allowPrivilegeEscalation: false
+        - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:a168c9fa095c88b3e0bcbbaa6d4501a8a02ab740b360938879ae9df55964a758
+          name: controller
+          ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       serviceAccountName: controller
 
 ---
@@ -1617,7 +1691,7 @@ kind: APIService
 metadata:
   labels:
     autoscaling.knative.dev/metric-provider: custom-metrics
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: v1beta1.custom.metrics.k8s.io
 spec:
   group: custom.metrics.k8s.io
@@ -1628,68 +1702,12 @@ spec:
     namespace: knative-serving
   version: v1beta1
   versionPriority: 100
-
----
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.9.0"
-  name: networking-istio
-  namespace: knative-serving
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: networking-istio
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: networking-istio
-    spec:
-      containers:
-      - env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:64b784b190c43427ecc66e7f12d892167a13f703aed0ff696a4ca6609ebb66f9
-        name: networking-istio
-        ports:
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-      serviceAccountName: controller
-
----
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    serving.knative.dev/release: "v0.9.0"
+    serving.knative.dev/release: "v0.10.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -1706,229 +1724,177 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.9.0"
+        serving.knative.dev/release: "v0.10.0"
     spec:
       containers:
-      - env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - name: METRICS_DOMAIN
-          value: knative.dev/serving
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:50b1a9fe29d661718b8935b58d1baf07e527dd0d4fb20061c9112d1eb5b88a8e
-        name: webhook
-        ports:
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 20m
-            memory: 20Mi
-        securityContext:
-          allowPrivilegeEscalation: false
+        - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:f59e8d9782f17b1af3060152d99b70ae08f40aa69b799180d24964e527ebb818
+          name: webhook
+          ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 20m
+              memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       serviceAccountName: controller
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   labels:
-    knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: configurations.serving.knative.dev
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.latestCreatedRevisionName
-    name: LatestCreated
-    type: string
-  - JSONPath: .status.latestReadyRevisionName
-    name: LatestReady
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
-  group: serving.knative.dev
-  names:
-    categories:
-    - all
-    - knative
-    - serving
-    kind: Configuration
-    plural: configurations
-    shortNames:
-    - config
-    - cfg
-    singular: configuration
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1
-    served: true
-    storage: false
-
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/controller: "true"
+    serving.knative.dev/release: "v0.10.0"
+  name: knative-serving-istio
+rules:
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - virtualservices
+      - gateways
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
 metadata:
   labels:
-    knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: revisions.serving.knative.dev
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: "v0.10.0"
+  name: knative-ingress-gateway
+  namespace: knative-serving
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
-    name: Config Name
-    type: string
-  - JSONPath: .status.serviceName
-    name: K8s Service Name
-    type: string
-  - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
-    name: Generation
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
-  group: serving.knative.dev
-  names:
-    categories:
-    - all
-    - knative
-    - serving
-    kind: Revision
-    plural: revisions
-    shortNames:
-    - rev
-    singular: revision
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1
-    served: true
-    storage: false
-
+  selector:
+    istio: ingressgateway
+  servers:
+    - hosts:
+        - '*'
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default Knative Gateway after v0.3. It points to the Istio
+    # standard istio-ingressgateway, instead of a custom one that we
+    # used pre-0.3.
+    gateway.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+
+    # A cluster local gateway to allow pods outside of the mesh to access
+    # Services and Routes not exposing through an ingress.  If the users
+    # do have a service mesh setup, this isn't required and can be removed.
+    #
+    # An example use case is when users want to use Istio without any
+    # sidecar injection (like Knative's istio-lean.yaml).  Since every pod
+    # is outside of the service mesh in that case, a cluster-local  service
+    # will need to be exposed to a cluster-local gateway to be accessible.
+    local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+
+    # To use only Istio service mesh and no cluster-local-gateway, replace
+    # all local-gateway.* entries the following entry.
+    local-gateway.mesh: "mesh"
+
+    # Feature flag to enable reconciling external Istio Gateways.
+    # When auto TLS feature is turned on, reconcileExternalGateway will be automatically enforced.
+    # 1. true: enabling reconciling external gateways.
+    # 2. false: disabling reconciling external gateways.
+    reconcileExternalGateway: "false"
+kind: ConfigMap
 metadata:
   labels:
-    knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: routes.serving.knative.dev
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.url
-    name: URL
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
-  group: serving.knative.dev
-  names:
-    categories:
-    - all
-    - knative
-    - serving
-    kind: Route
-    plural: routes
-    shortNames:
-    - rt
-    singular: route
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1
-    served: true
-    storage: false
-
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: "v0.10.0"
+  name: config-istio
+  namespace: knative-serving
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
-    knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.9.0"
-  name: services.serving.knative.dev
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: "v0.10.0"
+  name: networking-istio
+  namespace: knative-serving
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.url
-    name: URL
-    type: string
-  - JSONPath: .status.latestCreatedRevisionName
-    name: LatestCreated
-    type: string
-  - JSONPath: .status.latestReadyRevisionName
-    name: LatestReady
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
-    name: Reason
-    type: string
-  group: serving.knative.dev
-  names:
-    categories:
-    - all
-    - knative
-    - serving
-    kind: Service
-    plural: services
-    shortNames:
-    - kservice
-    - ksvc
-    singular: service
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
-  - name: v1
-    served: true
-    storage: false
-
----
+  replicas: 1
+  selector:
+    matchLabels:
+      app: networking-istio
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: networking-istio
+        serving.knative.dev/release: "v0.10.0"
+    spec:
+      containers:
+        - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:4bc49ca99adf8e4f5c498bdd1287cdf643e4b721e69b2c4a022fe98db46486ff
+          name: networking-istio
+          ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/deploy/resources/webhook/webhook.yaml
+++ b/deploy/resources/webhook/webhook.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    serving.knative.dev/release: "v0.10.0"
+  name: webhook.serving.knative.dev
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+    failurePolicy: Fail
+    name: webhook.serving.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    serving.knative.dev/release: "v0.10.0"
+  name: config.webhook.serving.knative.dev
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+    failurePolicy: Fail
+    name: config.webhook.serving.knative.dev
+    namespaceSelector:
+      matchExpressions:
+        - key: serving.knative.dev/release
+          operator: Exists

--- a/pkg/controller/knativeserving/knativeserving_controller.go
+++ b/pkg/controller/knativeserving/knativeserving_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-knative/knative-serving-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	"github.com/prometheus/client_golang/prometheus"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +30,8 @@ import (
 )
 
 const (
-	operand = "knative-serving"
+	operand     = "knative-serving"
+	webhookPath = "deploy/resources/webhook/webhook.yaml"
 )
 
 var (
@@ -151,6 +153,7 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 	stages := []func(*servingv1alpha1.KnativeServing) error{
 		r.ensureFinalizers,
 		r.initStatus,
+		r.checkWebhooks,
 		r.install,
 		r.checkDeployments,
 		r.deleteObsoleteResources,
@@ -176,6 +179,47 @@ func (r *ReconcileKnativeServing) initStatus(instance *servingv1alpha1.KnativeSe
 		}
 	}
 	return nil
+}
+
+// added changes in order to support release 0.10 please refer issue https://github.com/knative/serving-operator/issues/226
+func (r *ReconcileKnativeServing) checkWebhooks(instance *servingv1alpha1.KnativeServing) error {
+	if err := mutateWebhook(r.client); err != nil {
+		return err
+	}
+	return validateWebhook(r.client)
+}
+
+func mutateWebhook(cl client.Client) error {
+	mutatingWebhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "webhook.serving.knative.dev"}, mutatingWebhook)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return applyWebhook(cl)
+		}
+		return err
+	}
+	return nil
+}
+
+func validateWebhook(cl client.Client) error {
+	validateWebhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: "config.webhook.serving.knative.dev"}, validateWebhook)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return applyWebhook(cl)
+		}
+		return err
+	}
+	return nil
+}
+
+func applyWebhook(cl client.Client) error {
+	manifest, err := mf.NewManifest(webhookPath, false, cl)
+	if err != nil {
+		log.Error(err, "unable to create mutating webhook")
+		return err
+	}
+	return manifest.ApplyAll()
 }
 
 // Update the status subresource
@@ -243,7 +287,10 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 	if err := r.config.DeleteAll(); err != nil {
 		return err
 	}
-
+	// delete separately MutatingWebhookConfiguration and ValidatingWebhookConfiguration because those are not created as part of release yaml
+	if err := deleteWebhook(r.client); err != nil {
+		return err
+	}
 	// The deletionTimestamp might've changed. Fetch the resource again.
 	refetched := &servingv1alpha1.KnativeServing{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, refetched); err != nil {
@@ -251,6 +298,14 @@ func (r *ReconcileKnativeServing) delete(instance *servingv1alpha1.KnativeServin
 	}
 	refetched.SetFinalizers(refetched.GetFinalizers()[1:])
 	return r.client.Update(context.TODO(), refetched)
+}
+
+func deleteWebhook(cl client.Client) error {
+	manifest, err := mf.NewManifest(webhookPath, false, cl)
+	if err != nil {
+		return err
+	}
+	return manifest.DeleteAll()
 }
 
 // Expose metrics for installed knative serving operator

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.9.0"
+	Version = "0.10.0"
 )


### PR DESCRIPTION
1. used https://github.com/knative/serving/releases/download/v0.10.0/serving.yaml file to copy to 
    deploy/resources/knative-serving-0.10.0.yaml 
2. changed version to 0.10.0
3. moved MutatingWebhookConfiguration and ValidatingWebhookConfiguration from release manifest in order to solve https://github.com/knative/serving-operator/issues/226